### PR TITLE
Add debian-based Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+after_script:
+  - docker images
+
+language: bash
+
+script:
+  - docker build -t litecoind .
+  - docker run litecoind --version | grep "Litecoin Core"
+
+services: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:latest
+
+MAINTAINER João Fonseca <jfonseca@uphold.com>
+
+ENV GOSU_VERSION=1.7
+
+RUN useradd -r litecoin \
+  && apt-get update -y \
+  && apt-get install -y curl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && curl -o /usr/local/bin/gosu -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+	&& curl -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc | gpg --verify - /usr/local/bin/gosu \
+	&& chmod +x /usr/local/bin/gosu
+
+ENV LITECOIN_VERSION=0.10.4.0 \
+  LITECOIN_DATA=/home/litecoin/.litecoin
+
+RUN gpg --recv-key FE3348877809386C \
+  && curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux64.tar.gz \
+  && curl https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux64.tar.gz.asc | gpg --verify - litecoin-${LITECOIN_VERSION}-linux64.tar.gz \
+  && tar --strip=2 -xzf litecoin-${LITECOIN_VERSION}-linux64.tar.gz -C /usr/local/bin \
+  && rm litecoin-${LITECOIN_VERSION}-linux64.tar.gz
+
+EXPOSE 9332 9333 19332 19333 19444
+
+VOLUME ["/home/litecoin/.litecoin"]
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["litecoind"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # uphold/litecoind
+
 A litecoind docker image.
+
+[![uphold/litecoind][docker-pulls-image]][docker-hub-url] [![uphold/litecoind][docker-stars-image]][docker-hub-url] [![uphold/litecoind][docker-size-image]][docker-hub-url] [![uphold/litecoind][docker-layers-image]][docker-hub-url]
+
+## What is litecoind?
+
+litecoind is a program that implements the Litecoin protocol for remote procedure call (RPC) use. For more information see _[litecoinwiki](https://litecoin.info/Litecoin)_.
+
+## Usage
+
+### How to use this image
+
+This image contains the main binaries from the Litecoin Core project - `litecoind`, `litecoin-cli` and `litecoin-tx`. It behaves like a binary, so you can pass any arguments to the image and they will be forwarded to the `litecoind` binary:
+
+```sh
+$ docker run --rm -it uphold/litecoind \
+  -printtoconsole \
+  -regtest=1 \
+  -rpcallowip=172.17.0.0/16 \
+  -rpcpassword=bar \
+  -rpcuser=foo
+```
+
+By default, `litecoind` will run as user `litecoin` for security reasons and with its default data dir (`~/.litecoin`). If you'd like to customize where `litecoind` stores its data, you must use the `LITECOIN_DATA` environment variable. The directory will be automatically created with the correct permissions for the `litecoin` user and `litecoind` automatically configured to use it.
+
+```sh
+$ docker run -e LITECOIN_DATA=/var/lib/litecoind --rm uphold/litecoind \
+  -printtoconsole \
+  -regtest=1
+```
+
+You can also mount a directory in a volume under `/home/litecoin/.litecoin` in case you want to access it on the host:
+
+```sh
+$ docker run -v ${PWD}/data:/home/litecoin/.litecoin --rm uphold/litecoind \
+  -printtoconsole \
+  -regtest=1
+```
+
+You can optionally create a service using `docker-compose`:
+
+```yml
+litecoind:
+  image: uphold/litecoind
+  command:
+    -printtoconsole
+    -regtest=1
+```
+
+## Supported Docker versions
+
+This image is officially supported on Docker version 1.10, with support for older versions provided on a best-effort basis.
+
+## License
+
+The [uphold/docker-litecoind][docker-hub-url] docker project is under MIT license.
+
+[docker-hub-url]: https://hub.docker.com/r/uphold/litecoind
+[docker-layers-image]: https://img.shields.io/imagelayers/layers/uphold/litecoind/latest.svg?style=flat-square
+[docker-pulls-image]: https://img.shields.io/docker/pulls/uphold/litecoind.svg?style=flat-square
+[docker-size-image]: https://img.shields.io/imagelayers/image-size/uphold/litecoind/latest.svg?style=flat-square
+[docker-stars-image]: https://img.shields.io/docker/stars/uphold/litecoind.svg?style=flat-square

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for litecoind"
+
+  set -- litecoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "litecoind" ]; then
+  mkdir -p "$LITECOIN_DATA"
+  chmod 700 "$LITECOIN_DATA"
+  chown -R litecoin "$LITECOIN_DATA"
+
+  echo "$0: setting data directory to $LITECOIN_DATA"
+
+  set -- "$@" -datadir="$LITECOIN_DATA"
+fi
+
+if [ "$1" = "litecoind" ] || [ "$1" = "litecoin-cli" ] || [ "$1" = "litecoin-tx" ]; then
+  echo
+  exec gosu litecoin "$@"
+fi
+
+echo
+exec "$@"


### PR DESCRIPTION
Implementation of a Docker image based on debian, for litecoin binaries (litecoind, litecoin-cli and litecoin-tx).

Deprecates #1.
