### PR TITLE
Update litecoind@0.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - IMAGE="litecoind:${VERSION}"
 
 env:
+  - VERSION=0.14
   - VERSION=0.13
   - VERSION=0.10
 

--- a/0.14/Dockerfile
+++ b/0.14/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:wheezy-slim
+
+MAINTAINER João Fonseca <jfonseca@uphold.com>
+
+ENV GOSU_VERSION=1.9
+
+RUN useradd -r litecoin \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && curl -o /usr/local/bin/gosu -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+	&& curl -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc | gpg --verify - /usr/local/bin/gosu \
+	&& chmod +x /usr/local/bin/gosu
+
+ENV LITECOIN_VERSION=0.14.2 \
+  LITECOIN_DATA=/home/litecoin/.litecoin
+
+RUN gpg --recv-key FE3348877809386C \
+  && curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux-signatures.asc | gpg --verify - \
+  && tar --strip=2 -xzf litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz -C /usr/local/bin \
+  && rm litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
+
+EXPOSE 9332 9333 19332 19333 19444
+
+VOLUME ["/home/litecoin/.litecoin"]
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["litecoind"]

--- a/0.14/docker-entrypoint.sh
+++ b/0.14/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for litecoind"
+
+  set -- litecoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "litecoind" ]; then
+  mkdir -p "$LITECOIN_DATA"
+  chmod 700 "$LITECOIN_DATA"
+  chown -R litecoin "$LITECOIN_DATA"
+
+  echo "$0: setting data directory to $LITECOIN_DATA"
+
+  set -- "$@" -datadir="$LITECOIN_DATA"
+fi
+
+if [ "$1" = "litecoind" ] || [ "$1" = "litecoin-cli" ] || [ "$1" = "litecoin-tx" ]; then
+  echo
+  exec gosu litecoin "$@"
+fi
+
+echo
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A litecoind docker image.
 [![uphold/litecoind][docker-pulls-image]][docker-hub-url] [![uphold/litecoind][docker-stars-image]][docker-hub-url] [![uphold/litecoind][docker-size-image]][docker-hub-url] [![uphold/litecoind][docker-layers-image]][docker-hub-url]
 
 ## Supported tags and respective `Dockerfile` links
+- `0.14.2`, `0.14`, `latest` ([0.14/Dockerfile](https://github.com/uphold/docker-litecoind/blob/master/0.14/Dockerfile))
 - `0.13.2`, `0.13`, `latest` ([0.13/Dockerfile](https://github.com/uphold/docker-litecoind/blob/master/0.13/Dockerfile))
 - `0.10.4`, `0.10` ([0.10/Dockerfile](https://github.com/uphold/docker-litecoind/blob/master/0.10/Dockerfile))
 


### PR DESCRIPTION
This PR updates this `litecoind` Docker image to the `0.14.2` version of `litecoin-core` software.