### PR TITLE
Update general template for debian images

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -1,34 +1,48 @@
-FROM debian:wheezy-slim
+FROM debian:stable-slim
 
 MAINTAINER João Fonseca <jfonseca@uphold.com>
 
-ENV GOSU_VERSION=1.7
+RUN useradd -r litecoin
 
-RUN useradd -r litecoin \
-  && apt-get update -y \
+ENV GOSU_VERSION=1.10
+
+RUN apt-get update -y \
   && apt-get install -y curl gnupg \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
-	&& curl -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc | gpg --verify - /usr/local/bin/gosu \
-	&& chmod +x /usr/local/bin/gosu
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV LITECOIN_VERSION=0.10.4.0 \
-  LITECOIN_DATA=/home/litecoin/.litecoin
+RUN set -ex \
+  && for key in \
+    B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    FE3348877809386C \
+  ; do \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
 
-RUN gpg --recv-key FE3348877809386C \
-  && curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux64.tar.gz \
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+  && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
+
+ENV LITECOIN_VERSION=0.10.4.0
+ENV LITECOIN_DATA=/home/litecoin/.litecoin \
+  PATH=/opt/litecoin-${LITECOIN_VERSION}/bin:$PATH
+
+RUN curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux64.tar.gz \
   && curl https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux64.tar.gz.asc | gpg --verify - litecoin-${LITECOIN_VERSION}-linux64.tar.gz \
-  && tar --strip=2 -xzf litecoin-${LITECOIN_VERSION}-linux64.tar.gz -C /usr/local/bin \
+  && tar -xzf litecoin-${LITECOIN_VERSION}-linux64.tar.gz -C /opt \
   && rm litecoin-${LITECOIN_VERSION}-linux64.tar.gz
-
-EXPOSE 9332 9333 19332 19333 19444
 
 VOLUME ["/home/litecoin/.litecoin"]
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9332 9333 19332 19333 19444
 
 CMD ["litecoind"]

--- a/0.13/Dockerfile
+++ b/0.13/Dockerfile
@@ -1,34 +1,48 @@
-FROM debian:wheezy-slim
+FROM debian:stable-slim
 
 MAINTAINER João Fonseca <jfonseca@uphold.com>
 
-ENV GOSU_VERSION=1.9
+RUN useradd -r litecoin
 
-RUN useradd -r litecoin \
-  && apt-get update -y \
+ENV GOSU_VERSION=1.10
+
+RUN apt-get update -y \
   && apt-get install -y curl gnupg \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
-	&& curl -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc | gpg --verify - /usr/local/bin/gosu \
-	&& chmod +x /usr/local/bin/gosu
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV LITECOIN_VERSION=0.13.2 \
-  LITECOIN_DATA=/home/litecoin/.litecoin
+RUN set -ex \
+  && for key in \
+    B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    FE3348877809386C \
+  ; do \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
 
-RUN gpg --recv-key FE3348877809386C \
-  && curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+  && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
+
+ENV LITECOIN_VERSION=0.13.2
+ENV LITECOIN_DATA=/home/litecoin/.litecoin \
+  PATH=/opt/litecoin-${LITECOIN_VERSION}/bin:$PATH
+
+RUN curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && curl https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux-signatures.asc | gpg --verify - \
-  && tar --strip=2 -xzf litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz -C /usr/local/bin \
+  && tar -xzf litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz -C /opt \
   && rm litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
-
-EXPOSE 9332 9333 19332 19333 19444
 
 VOLUME ["/home/litecoin/.litecoin"]
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9332 9333 19332 19333 19444
 
 CMD ["litecoind"]

--- a/0.14/Dockerfile
+++ b/0.14/Dockerfile
@@ -1,34 +1,48 @@
-FROM debian:wheezy-slim
+FROM debian:stable-slim
 
 MAINTAINER João Fonseca <jfonseca@uphold.com>
 
-ENV GOSU_VERSION=1.9
+RUN useradd -r litecoin
 
-RUN useradd -r litecoin \
-  && apt-get update -y \
+ENV GOSU_VERSION=1.10
+
+RUN apt-get update -y \
   && apt-get install -y curl gnupg \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  && curl -o /usr/local/bin/gosu -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
-	&& curl -L https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc | gpg --verify - /usr/local/bin/gosu \
-	&& chmod +x /usr/local/bin/gosu
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV LITECOIN_VERSION=0.14.2 \
-  LITECOIN_DATA=/home/litecoin/.litecoin
+RUN set -ex \
+  && for key in \
+    B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    FE3348877809386C \
+  ; do \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
 
-RUN gpg --recv-key FE3348877809386C \
-  && curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+  && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
+
+ENV LITECOIN_VERSION=0.14.2
+ENV LITECOIN_DATA=/home/litecoin/.litecoin \
+  PATH=/opt/litecoin-${LITECOIN_VERSION}/bin:$PATH
+
+RUN curl -O https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && curl https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-linux-signatures.asc | gpg --verify - \
-  && tar --strip=2 -xzf litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz -C /usr/local/bin \
+  && tar -xzf litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz -C /opt \
   && rm litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz
-
-EXPOSE 9332 9333 19332 19333 19444
 
 VOLUME ["/home/litecoin/.litecoin"]
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9332 9333 19332 19333 19444
 
 CMD ["litecoind"]


### PR DESCRIPTION
* Update debian to `stable-slim` to reduce maintenance time.
* Update gosu to 1.10.
* Add more robust GPG key handling.
* Extract binaries to `/opt` instead of `/usr/local/bin` and into their own folder.