### PR TITLE
Add litecoin-core@0.21.2.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '0.21'
           - '0.18'
           - '0.17'
           - '0.16'

--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -1,0 +1,51 @@
+FROM debian:stable-slim
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN useradd -r litecoin \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && set -ex \
+  && for key in \
+    # Litecoin (davidburkett38’s key)
+    3620E9D387E55666 \
+    # Gosu (tianon's key)
+    B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  ; do \
+    gpg --no-tty --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --no-tty --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --no-tty --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
+
+ENV GOSU_VERSION=1.10
+
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+  && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
+
+ENV LITECOIN_VERSION=0.21.2.1
+ENV LITECOIN_DATA=/home/litecoin/.litecoin
+
+RUN curl -SLO https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/SHA256SUMS.asc \
+  && gpg --verify SHA256SUMS.asc \
+  && grep $(sha256sum litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz | awk '{ print $1 }') SHA256SUMS.asc \
+  && tar --strip=2 -xzf *.tar.gz -C /usr/local/bin \
+  && rm *.tar.gz
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/litecoin/.litecoin"]
+
+EXPOSE 9332 9333 19332 19333 19444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["litecoind"]

--- a/0.21/docker-entrypoint.sh
+++ b/0.21/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for litecoind"
+
+  set -- litecoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "litecoind" ]; then
+  mkdir -p "$LITECOIN_DATA"
+  chmod 770 "$LITECOIN_DATA" || echo "Could not chmod $LITECOIN_DATA (may not have appropriate permissions)"
+  chown -R litecoin "$LITECOIN_DATA" || echo "Could not chown $LITECOIN_DATA (may not have appropriate permissions)"
+
+  echo "$0: setting data directory to $LITECOIN_DATA"
+
+  set -- "$@" -datadir="$LITECOIN_DATA"
+fi
+
+if [ "$(id -u)" = "0" ] && ([ "$1" = "litecoind" ] || [ "$1" = "litecoin-cli" ] || [ "$1" = "litecoin-tx" ]); then
+  set -- gosu litecoin "$@"
+fi
+
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A Litecoin Core docker image.
 
 ## Tags
 
-- `0.18.1`, `0.18`, `latest` ([0.18/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.18/Dockerfile))
+- `0.21.2.1`, `0.21`, `latest` ([0.21/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.21/Dockerfile))
+- `0.18.1`, `0.18` ([0.18/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.18/Dockerfile))
 - `0.17.1`, `0.17` ([0.17/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.17/Dockerfile))
 - `0.16.3`, `0.16` ([0.16/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.16/Dockerfile))
 - `0.15.1`, `0.15` ([0.15/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.15/Dockerfile))


### PR DESCRIPTION
We're adding the new version [0.21.2.1 ](https://github.com/litecoin-project/litecoin/releases/tag/v0.21.2).

Added new key identifier [0x3620e9d387e55666 ](https://pgp.mit.edu/pks/lookup?op=get&search=0x3620E9D387E55666)(davidburkett38’s key) to Dockerfile to verify the integrity of the released binaries.