### PR TITLE
Bump litecoin-core 0.21

### DIFF
--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/dow
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
 
-ENV LITECOIN_VERSION=0.21.2.1
+ENV LITECOIN_VERSION=0.21.2.2
 ENV LITECOIN_DATA=/home/litecoin/.litecoin
 
 RUN curl -SLO https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-x86_64-linux-gnu.tar.gz \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Litecoin Core docker image.
 
 ## Tags
 
-- `0.21.2.1`, `0.21`, `latest` ([0.21/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.21/Dockerfile))
+- `0.21.2.2`, `0.21`, `latest` ([0.21/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.21/Dockerfile))
 - `0.18.1`, `0.18` ([0.18/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.18/Dockerfile))
 - `0.17.1`, `0.17` ([0.17/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.17/Dockerfile))
 - `0.16.3`, `0.16` ([0.16/Dockerfile](https://github.com/uphold/docker-litecoin-core/blob/master/0.16/Dockerfile))


### PR DESCRIPTION
Bumps litecoin-core 0.21 from 0.21.2.1 to 0.21.2.2

https://github.com/litecoin-project/litecoin/releases/tag/v0.21.2.2